### PR TITLE
Add protocol 'constants'

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -762,6 +762,28 @@ impl Type {
     }
 }
 
+impl ::Protocol {
+    /// Protocol corresponding to `ICMPv4`
+    pub fn icmpv4() -> Self {
+        ::Protocol(sys::IPPROTO_ICMP)
+    }
+
+    /// Protocol corresponding to `ICMPv6`
+    pub fn icmpv6() -> Self {
+        ::Protocol(sys::IPPROTO_ICMPV6)
+    }
+
+    /// Protocol corresponding to `TCP`
+    pub fn tcp() -> Self {
+        ::Protocol(sys::IPPROTO_TCP)
+    }
+
+    /// Protocol corresponding to `UDP`
+    pub fn udp() -> Self {
+        ::Protocol(sys::IPPROTO_UDP)
+    }
+}
+
 impl From<i32> for Type {
     fn from(a: i32) -> Type {
         Type(a)

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -62,6 +62,11 @@ cfg_if! {
 use SockAddr;
 use utils::One;
 
+pub const IPPROTO_ICMP: i32 = libc::IPPROTO_ICMP;
+pub const IPPROTO_ICMPV6: i32 = libc::IPPROTO_ICMPV6;
+pub const IPPROTO_TCP: i32 = libc::IPPROTO_TCP;
+pub const IPPROTO_UDP: i32 = libc::IPPROTO_UDP;
+
 #[macro_use]
 #[cfg(target_os = "linux")]
 mod weak;

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -34,6 +34,11 @@ const SD_SEND: c_int = 1;
 const SIO_KEEPALIVE_VALS: DWORD = 0x98000004;
 const WSA_FLAG_OVERLAPPED: DWORD = 0x01;
 
+pub const IPPROTO_ICMP: i32 = ws2def::IPPROTO_ICMP.0 as i32;
+pub const IPPROTO_ICMPV6: i32 = ws2def::IPPROTO_ICMPV6.0 as i32;
+pub const IPPROTO_TCP: i32 = ws2def::IPPROTO_TCP.0 as i32;
+pub const IPPROTO_UDP: i32 = ws2def::IPPROTO_UDP.0 as i32;
+
 #[repr(C)]
 struct tcp_keepalive {
     onoff: c_ulong,
@@ -420,7 +425,7 @@ impl Socket {
 
     pub fn nodelay(&self) -> io::Result<bool> {
         unsafe {
-            let raw: c_int = self.getsockopt(IPPROTO_TCP.0 as c_int,
+            let raw: c_int = self.getsockopt(IPPROTO_TCP,
                                              TCP_NODELAY)?;
             Ok(raw != 0)
         }
@@ -428,7 +433,7 @@ impl Socket {
 
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
         unsafe {
-            self.setsockopt(IPPROTO_TCP.0 as c_int,
+            self.setsockopt(IPPROTO_TCP,
                             TCP_NODELAY,
                             nodelay as c_int)
         }


### PR DESCRIPTION
I'd prefer to have constants as actual constants instead of creating it through functions but I decided to follow style as with Domain.

Due to difference in how these constants defined in winapi and libc I put implementation in sys module as otherwise I would just need to re-define all these constants in sys module...