### PR TITLE
Update winapi dep to 0.3, and update code to support it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,9 @@ possible intended.
 [package.metadata.docs.rs]
 all-features = true
 
-[target."cfg(windows)".dependencies]
-ws2_32-sys = "0.2"
-winapi = "0.2"
-kernel32-sys = "0.2"
+[target."cfg(windows)".dependencies.winapi]
+version = "0.3"
+features = ["handleapi", "ws2def", "ws2ipdef", "ws2tcpip"]
 
 [target."cfg(unix)".dependencies]
 cfg-if = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,16 +40,15 @@
 #[cfg(unix)] extern crate libc;
 #[cfg(unix)] #[macro_use] extern crate cfg_if;
 
-#[cfg(windows)] extern crate kernel32;
 #[cfg(windows)] extern crate winapi;
-#[cfg(windows)] extern crate ws2_32;
 
 #[cfg(test)] extern crate tempdir;
 
 use utils::NetInt;
 
 #[cfg(unix)] use libc::{sockaddr_storage, socklen_t};
-#[cfg(windows)] use winapi::{SOCKADDR_STORAGE as sockaddr_storage, socklen_t};
+#[cfg(windows)] use winapi::shared::ws2def::SOCKADDR_STORAGE as sockaddr_storage;
+#[cfg(windows)] use winapi::um::ws2tcpip::socklen_t;
 
 mod sockaddr;
 mod socket;

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -7,9 +7,13 @@ use std::ptr;
 use libc::{sockaddr, sockaddr_storage, sockaddr_in, sockaddr_in6, sa_family_t, socklen_t, AF_INET,
            AF_INET6};
 #[cfg(windows)]
-use winapi::{SOCKADDR as sockaddr, SOCKADDR_STORAGE as sockaddr_storage,
-             SOCKADDR_IN as sockaddr_in, sockaddr_in6,
-             ADDRESS_FAMILY as sa_family_t, socklen_t, AF_INET, AF_INET6};
+use winapi::shared::ws2def::{
+    SOCKADDR as sockaddr, SOCKADDR_STORAGE as sockaddr_storage,
+    SOCKADDR_IN as sockaddr_in,
+    ADDRESS_FAMILY as sa_family_t, AF_INET, AF_INET6
+};
+#[cfg(windows)] use winapi::shared::ws2ipdef::SOCKADDR_IN6_LH as sockaddr_in6;
+#[cfg(windows)] use winapi::um::ws2tcpip::socklen_t;
 
 use SockAddr;
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -18,7 +18,7 @@ use std::os::unix::net::{UnixDatagram, UnixListener, UnixStream};
 #[cfg(unix)]
 use libc as c;
 #[cfg(windows)]
-use winapi as c;
+use winapi::shared::ws2def as c;
 
 use sys;
 use {Socket, Protocol, Domain, Type, SockAddr};


### PR DESCRIPTION
This PR adds support for winapi 0.3 to socket2-rs. A few things to keep in mind:

- Since this library exposes winapi types in public interfaces, the version should probably be bumped to 0.3 as upgrading may be a breaking change.
- Currently this doesn't build with the winapi 0.3.2, as the `SOCKADDR_IN6_LH` struct is only in git.. This does build (and passes tests) on windows when compiled with the below additions to the winapi dep in Cargo.toml:
```
git = "https://github.com/retep998/winapi-rs.git"
branch = "0.3"
```
- The `SOCKET` type in winapi is now `usize` instead of `u64`, which doesn't match the `std::os::windows::io::RawSocket` type in Rust that's still `u64`. So this PR casts between them in a few places.