### PR TITLE
Fix newtype conversions to i32

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -808,7 +808,7 @@ impl From<i32> for Domain {
 
 impl From<Domain> for i32 {
     fn from(a: Domain) -> i32 {
-        a.into()
+        a.0
     }
 }
 
@@ -868,7 +868,7 @@ impl From<i32> for Type {
 
 impl From<Type> for i32 {
     fn from(a: Type) -> i32 {
-        a.into()
+        a.0
     }
 }
 
@@ -880,7 +880,7 @@ impl From<i32> for Protocol {
 
 impl From<Protocol> for i32 {
     fn from(a: Protocol) -> i32 {
-        a.into()
+        a.0
     }
 }
 


### PR DESCRIPTION
`i32::from(Protocol::tcp())` currently causes stack overflow. Oops!