### PR TITLE
Fix Socket::nodelay() for Windows

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -982,4 +982,16 @@ mod test {
         #[cfg(unix)]
         assert_eq!(socket.keepalive().unwrap(), None);
     }
+
+    #[test]
+    fn nodelay() {
+        let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+
+        assert!(socket.set_nodelay(true).is_ok());
+
+        let result = socket.nodelay();
+
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
 }

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -445,13 +445,13 @@ impl Socket {
 
     pub fn nodelay(&self) -> io::Result<bool> {
         unsafe {
-            let raw: c_int = self.getsockopt(IPPROTO_TCP, TCP_NODELAY)?;
+            let raw: c_char = self.getsockopt(IPPROTO_TCP, TCP_NODELAY)?;
             Ok(raw != 0)
         }
     }
 
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
-        unsafe { self.setsockopt(IPPROTO_TCP, TCP_NODELAY, nodelay as c_int) }
+        unsafe { self.setsockopt(IPPROTO_TCP, TCP_NODELAY, nodelay as c_char) }
     }
 
     pub fn broadcast(&self) -> io::Result<bool> {


### PR DESCRIPTION
This fixes `Socket::nodelay()` and `Socket::set_nodelay()` for Windows by using a `c_char` instead of a `c_int`, ensuring the type size assertion in `getsockopt` does not fail.

This fixes https://github.com/alexcrichton/socket2-rs/issues/31