### PR TITLE
cfg-if: require 0.1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.3.3"
 features = ["handleapi", "ws2def", "ws2ipdef", "ws2tcpip", "minwindef"]
 
 [target."cfg(any(unix, target_os = \"redox\"))".dependencies]
-cfg-if = "0.1"
+cfg-if = "0.1.6"
 libc = "0.2.42"
 
 [target."cfg(target_os = \"redox\")".dependencies]


### PR DESCRIPTION
This version compiles with modern toolchains.