### PR TITLE
Support Out-of-Band related functionality

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1035,7 +1035,8 @@ mod test {
     #[cfg(all(unix, feature = "pair"))]
     fn tcp() {
         let s1 = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
-        s1.bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into()).unwrap();
+        s1.bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into())
+            .unwrap();
         let s1_addr = s1.local_addr().unwrap();
         s1.listen(1).unwrap();
 
@@ -1048,5 +1049,4 @@ mod test {
         assert_eq!(s2.send(b"hello world", 0).unwrap(), 11);
         assert_eq!(s3.recv(&mut buf, 0).unwrap(), 11);
     }
-
 }

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -745,7 +745,7 @@ impl Read for Socket {
 
 impl<'a> Read for &'a Socket {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.recv(buf)
+        self.recv(buf, 0)
     }
 }
 
@@ -761,7 +761,7 @@ impl Write for Socket {
 
 impl<'a> Write for &'a Socket {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.send(buf)
+        self.send(buf, 0)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -285,14 +285,14 @@ impl Socket {
         }
     }
 
-    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+    pub fn recv(&self, buf: &mut [u8], flags: c_int) -> io::Result<usize> {
         unsafe {
             let n = {
                 sock::recv(
                     self.socket,
                     buf.as_mut_ptr() as *mut c_char,
                     clamp(buf.len()),
-                    0,
+                    flags,
                 )
             };
             match n {
@@ -321,15 +321,11 @@ impl Socket {
         }
     }
 
-    pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SockAddr)> {
-        self.recvfrom(buf, 0)
-    }
-
     pub fn peek_from(&self, buf: &mut [u8]) -> io::Result<(usize, SockAddr)> {
-        self.recvfrom(buf, MSG_PEEK)
+        self.recv_from(buf, MSG_PEEK)
     }
 
-    fn recvfrom(&self, buf: &mut [u8], flags: c_int) -> io::Result<(usize, SockAddr)> {
+    pub fn recv_from(&self, buf: &mut [u8], flags: c_int) -> io::Result<(usize, SockAddr)> {
         unsafe {
             let mut storage: SOCKADDR_STORAGE = mem::zeroed();
             let mut addrlen = mem::size_of_val(&storage) as c_int;
@@ -354,14 +350,14 @@ impl Socket {
         }
     }
 
-    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+    pub fn send(&self, buf: &[u8], flags: c_int) -> io::Result<usize> {
         unsafe {
             let n = {
                 sock::send(
                     self.socket,
                     buf.as_ptr() as *const c_char,
                     clamp(buf.len()),
-                    0,
+                    flags,
                 )
             };
             if n == sock::SOCKET_ERROR {
@@ -372,14 +368,14 @@ impl Socket {
         }
     }
 
-    pub fn send_to(&self, buf: &[u8], addr: &SockAddr) -> io::Result<usize> {
+    pub fn send_to(&self, buf: &[u8], flags: c_int, addr: &SockAddr) -> io::Result<usize> {
         unsafe {
             let n = {
                 sock::sendto(
                     self.socket,
                     buf.as_ptr() as *const c_char,
                     clamp(buf.len()),
-                    0,
+                    flags,
                     addr.as_ptr(),
                     addr.len(),
                 )
@@ -688,6 +684,17 @@ impl Socket {
         }
     }
 
+    pub fn out_of_band_inline(&self) -> io::Result<bool> {
+        unsafe {
+            let raw: c_int = self.getsockopt(SOL_SOCKET, SO_OOBINLINE)?;
+            Ok(raw != 0)
+        }
+    }
+
+    pub fn set_out_of_band_inline(&self, oob_inline: bool) -> io::Result<()> {
+        unsafe { self.setsockopt(SOL_SOCKET, SO_OOBINLINE, oob_inline as c_int) }
+    }
+
     unsafe fn setsockopt<T>(&self, opt: c_int, val: c_int, payload: T) -> io::Result<()>
     where
         T: Copy,
@@ -974,4 +981,13 @@ fn dur2linger(dur: Option<Duration>) -> sock::linger {
 fn test_ip() {
     let ip = Ipv4Addr::new(127, 0, 0, 1);
     assert_eq!(ip, from_s_addr(to_s_addr(&ip)));
+}
+
+#[test]
+fn test_out_of_band_inline() {
+    let tcp = Socket::new(AF_INET, SOCK_STREAM, 0).unwrap();
+    assert_eq!(tcp.out_of_band_inline().unwrap(), false);
+
+    tcp.set_out_of_band_inline(true).unwrap();
+    assert_eq!(tcp.out_of_band_inline().unwrap(), true);
 }


### PR DESCRIPTION
This PR adds the ability to get/set SO_OOBINLINE flag for `Socket`s via the `set_out_of_band_inline`/`out_of_band_inline` methods.
Also, this PR exposes the `flags` argument of `send`/`recv` etc. methods to allow caller to specify arbitrary flags, including the `MSG_OOB` when needed.

This feature allows TCP sockets utilizing `socket2` to comply with RFC6093 regarding Urgent data etc., and allows for other uses of `send`\`recv` flags as well.