### PR TITLE
Move Domain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,48 @@ pub struct SockAddr {
 #[derive(Copy, Clone)]
 pub struct Domain(i32);
 
+impl Domain {
+    /// Domain for IPv4 communication, corresponding to `AF_INET`.
+    pub fn ipv4() -> Domain {
+        Domain(libc::AF_INET)
+    }
+
+    /// Domain for IPv6 communication, corresponding to `AF_INET6`.
+    pub fn ipv6() -> Domain {
+        Domain(libc::AF_INET6)
+    }
+
+    /// Domain for Unix socket communication, corresponding to `AF_UNIX`.
+    ///
+    /// This function is only available on Unix when the `unix` feature is
+    /// activated.
+    #[cfg(all(unix, feature = "unix"))]
+    pub fn unix() -> Domain {
+        Domain(libc::AF_UNIX)
+    }
+
+    /// Domain for low-level packet interface, corresponding to `AF_PACKET`.
+    ///
+    /// This function is only available on Linux when the `unix` feature is
+    /// activated.
+    #[cfg(all(unix, feature = "unix", target_os = "linux"))]
+    pub fn packet() -> Domain {
+        Domain(libc::AF_PACKET)
+    }
+}
+
+impl From<libc::c_int> for Domain {
+    fn from(a: libc::c_int) -> Domain {
+        Domain(a)
+    }
+}
+
+impl From<Domain> for libc::c_int {
+    fn from(a: Domain) -> libc::c_int {
+        a.0
+    }
+}
+
 /// Specification of communication semantics on a socket.
 ///
 /// This is a newtype wrapper around an integer which provides a nicer API in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,24 +117,6 @@ impl Domain {
     pub fn ipv6() -> Domain {
         Domain(libc::AF_INET6)
     }
-
-    /// Domain for Unix socket communication, corresponding to `AF_UNIX`.
-    ///
-    /// This function is only available on Unix when the `unix` feature is
-    /// activated.
-    #[cfg(all(unix, feature = "unix"))]
-    pub fn unix() -> Domain {
-        Domain(libc::AF_UNIX)
-    }
-
-    /// Domain for low-level packet interface, corresponding to `AF_PACKET`.
-    ///
-    /// This function is only available on Linux when the `unix` feature is
-    /// activated.
-    #[cfg(all(unix, feature = "unix", target_os = "linux"))]
-    pub fn packet() -> Domain {
-        Domain(libc::AF_PACKET)
-    }
 }
 
 impl From<libc::c_int> for Domain {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ mod sys;
 #[path = "sys/windows.rs"]
 mod sys;
 
+use sys::c_int;
+
 /// Newtype, owned, wrapper around a system socket.
 ///
 /// This type simply wraps an instance of a file descriptor (`c_int`) on Unix
@@ -110,24 +112,24 @@ pub struct Domain(i32);
 impl Domain {
     /// Domain for IPv4 communication, corresponding to `AF_INET`.
     pub fn ipv4() -> Domain {
-        Domain(libc::AF_INET)
+        Domain(sys::AF_INET)
     }
 
     /// Domain for IPv6 communication, corresponding to `AF_INET6`.
     pub fn ipv6() -> Domain {
-        Domain(libc::AF_INET6)
+        Domain(sys::AF_INET6)
     }
 }
 
-impl From<libc::c_int> for Domain {
-    fn from(a: libc::c_int) -> Domain {
-        Domain(a)
+impl From<c_int> for Domain {
+    fn from(d: c_int) -> Domain {
+        Domain(d)
     }
 }
 
-impl From<Domain> for libc::c_int {
-    fn from(a: Domain) -> libc::c_int {
-        a.0
+impl From<Domain> for c_int {
+    fn from(d: Domain) -> c_int {
+        d.0
     }
 }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -864,48 +864,6 @@ impl From<Socket> for UnixDatagram {
     }
 }
 
-impl Domain {
-    /// Domain for IPv4 communication, corresponding to `AF_INET`.
-    pub fn ipv4() -> Domain {
-        Domain(c::AF_INET)
-    }
-
-    /// Domain for IPv6 communication, corresponding to `AF_INET6`.
-    pub fn ipv6() -> Domain {
-        Domain(c::AF_INET6)
-    }
-
-    /// Domain for Unix socket communication, corresponding to `AF_UNIX`.
-    ///
-    /// This function is only available on Unix when the `unix` feature is
-    /// activated.
-    #[cfg(all(unix, feature = "unix"))]
-    pub fn unix() -> Domain {
-        Domain(c::AF_UNIX)
-    }
-
-    /// Domain for low-level packet interface, corresponding to `AF_PACKET`.
-    ///
-    /// This function is only available on Linux when the `unix` feature is
-    /// activated.
-    #[cfg(all(unix, feature = "unix", target_os = "linux"))]
-    pub fn packet() -> Domain {
-        Domain(c::AF_PACKET)
-    }
-}
-
-impl From<i32> for Domain {
-    fn from(a: i32) -> Domain {
-        Domain(a)
-    }
-}
-
-impl From<Domain> for i32 {
-    fn from(a: Domain) -> i32 {
-        a.0
-    }
-}
-
 impl Type {
     /// Type corresponding to `SOCK_STREAM`
     ///

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -22,10 +22,15 @@ use std::os::unix::prelude::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
-use libc::{self, c_int, c_void, socklen_t, ssize_t};
+use libc::{self, c_void, socklen_t, ssize_t};
 
 use crate::Domain;
 
+#[allow(non_camel_case_types)]
+pub(crate) type c_int = libc::c_int;
+
+// Used in `Domain`.
+pub(crate) use libc::{AF_INET, AF_INET6};
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "dragonfly", target_os = "freebsd",
                  target_os = "ios", target_os = "macos",
@@ -39,6 +44,8 @@ cfg_if::cfg_if! {
         use libc::IPV6_DROP_MEMBERSHIP;
     }
 }
+// Used in `Type`.
+pub(crate) use libc::{SOCK_RAW, SOCK_SEQPACKET};
 
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "linux", target_os = "android",
@@ -68,15 +75,6 @@ pub const IPPROTO_ICMP: i32 = libc::IPPROTO_ICMP;
 pub const IPPROTO_ICMPV6: i32 = libc::IPPROTO_ICMPV6;
 pub const IPPROTO_TCP: i32 = libc::IPPROTO_TCP;
 pub const IPPROTO_UDP: i32 = libc::IPPROTO_UDP;
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "redox")] {
-        pub const SOCK_RAW: i32 = -1;
-        pub const SOCK_SEQPACKET: i32 = -1;
-    } else {
-        pub const SOCK_SEQPACKET: i32 = libc::SOCK_SEQPACKET;
-        pub const SOCK_RAW: i32 = libc::SOCK_RAW;
-    }
-}
 
 /// Unix only API.
 impl Domain {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -24,6 +24,8 @@ use std::time::{Duration, Instant};
 
 use libc::{self, c_int, c_void, socklen_t, ssize_t};
 
+use crate::Domain;
+
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "dragonfly", target_os = "freebsd",
                  target_os = "ios", target_os = "macos",
@@ -73,6 +75,24 @@ cfg_if::cfg_if! {
     } else {
         pub const SOCK_SEQPACKET: i32 = libc::SOCK_SEQPACKET;
         pub const SOCK_RAW: i32 = libc::SOCK_RAW;
+    }
+}
+
+/// Unix only API.
+impl Domain {
+    /// Domain for Unix socket communication, corresponding to `AF_UNIX`.
+    pub fn unix() -> Domain {
+        Domain(libc::AF_UNIX)
+    }
+
+    /// Domain for low-level packet interface, corresponding to `AF_PACKET`.
+    ///
+    /// # Notes
+    ///
+    /// This function is only available on Linux.
+    #[cfg(target_os = "linux")]
+    pub fn packet() -> Domain {
+        Domain(libc::AF_PACKET)
     }
 }
 

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -20,7 +20,7 @@ use std::ptr;
 use std::sync::{Once, ONCE_INIT};
 use std::time::Duration;
 
-use winapi::ctypes::{c_char, c_int, c_long, c_ulong};
+use winapi::ctypes::{c_char, c_long, c_ulong};
 use winapi::shared::in6addr::*;
 use winapi::shared::inaddr::*;
 use winapi::shared::minwindef::DWORD;
@@ -47,8 +47,14 @@ pub const IPPROTO_ICMP: i32 = ws2def::IPPROTO_ICMP as i32;
 pub const IPPROTO_ICMPV6: i32 = ws2def::IPPROTO_ICMPV6 as i32;
 pub const IPPROTO_TCP: i32 = ws2def::IPPROTO_TCP as i32;
 pub const IPPROTO_UDP: i32 = ws2def::IPPROTO_UDP as i32;
-pub const SOCK_SEQPACKET: i32 = ws2def::SOCK_SEQPACKET as i32;
-pub const SOCK_RAW: i32 = ws2def::SOCK_RAW as i32;
+
+#[allow(non_camel_case_types)]
+pub(crate) type c_int = winapi::ctypes::c_int;
+
+// Used in `Domain`.
+pub(crate) use winapi::shared::ws2def::{AF_INET, AF_INET6};
+// Used in `Type`.
+pub(crate) use winapi::shared::ws2def::{SOCK_RAW, SOCK_SEQPACKET};
 
 #[repr(C)]
 struct tcp_keepalive {


### PR DESCRIPTION
Moves `Domain` impl to where the type is defined  and moves Unix only `Domain` methods to unix file.