### PR TITLE
Always use C's int type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,10 +104,10 @@ pub struct SockAddr {
 /// such as `Domain::ipv4`, `Domain::ipv6`, etc, are provided to avoid reaching
 /// into libc for various constants.
 ///
-/// This type is freely interconvertible with the `i32` type, however, if a raw
+/// This type is freely interconvertible with C's `int` type, however, if a raw
 /// value needs to be provided.
 #[derive(Copy, Clone)]
-pub struct Domain(i32);
+pub struct Domain(c_int);
 
 impl Domain {
     /// Domain for IPv4 communication, corresponding to `AF_INET`.
@@ -140,20 +140,20 @@ impl From<Domain> for c_int {
 /// such as `Type::stream`, `Type::dgram`, etc, are provided to avoid reaching
 /// into libc for various constants.
 ///
-/// This type is freely interconvertible with the `i32` type, however, if a raw
+/// This type is freely interconvertible with C's `int` type, however, if a raw
 /// value needs to be provided.
 #[derive(Copy, Clone)]
-pub struct Type(i32);
+pub struct Type(c_int);
 
 /// Protocol specification used for creating sockets via `Socket::new`.
 ///
 /// This is a newtype wrapper around an integer which provides a nicer API in
 /// addition to an injection point for documentation.
 ///
-/// This type is freely interconvertible with the `i32` type, however, if a raw
+/// This type is freely interconvertible with C's `int` type, however, if a raw
 /// value needs to be provided.
 #[derive(Copy, Clone)]
-pub struct Protocol(i32);
+pub struct Protocol(c_int);
 
 fn hton<I: NetInt>(i: I) -> I {
     i.to_be()

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -26,8 +26,7 @@ use libc::{self, c_void, socklen_t, ssize_t};
 
 use crate::Domain;
 
-#[allow(non_camel_case_types)]
-pub(crate) type c_int = libc::c_int;
+pub use libc::c_int;
 
 // Used in `Domain`.
 pub(crate) use libc::{AF_INET, AF_INET6};

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -48,8 +48,7 @@ pub const IPPROTO_ICMPV6: i32 = ws2def::IPPROTO_ICMPV6 as i32;
 pub const IPPROTO_TCP: i32 = ws2def::IPPROTO_TCP as i32;
 pub const IPPROTO_UDP: i32 = ws2def::IPPROTO_UDP as i32;
 
-#[allow(non_camel_case_types)]
-pub(crate) type c_int = winapi::ctypes::c_int;
+pub use winapi::ctypes::c_int;
 
 // Used in `Domain`.
 pub(crate) use winapi::shared::ws2def::{AF_INET, AF_INET6};


### PR DESCRIPTION
Although most platforms use a signed 32bit integer (i32) as C's int type it
is allowed to only be 16 bits or larger than 32 bit. Using the type as
defined by libc/winapi ensures we don't have to worry about it.