### PR TITLE
 Implement fmt::Debug for Domain, Protocol and Type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,44 @@
 
 use crate::utils::NetInt;
 
+/// Macro to implement `fmt::Debug` for a type, printing the constant names
+/// rather than a number.
+///
+/// Note this is used in the `sys` module and thus must be defined before
+/// defining the modules.
+macro_rules! impl_debug {
+    (
+        // Type for which to implement `fmt::Debug`.
+        $type: path,
+        $(
+            $(#[$target: meta])*
+            // The flag(s) to check.
+            // Need to specific the libc crate because Windows doesn't use
+            // `libc` but `winapi`.
+            $libc: ident :: $flag: ident
+        ),+ $(,)*
+    ) => {
+        impl std::fmt::Debug for $type {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let string = match self.0 {
+                    $(
+                        $(#[$target])*
+                        $libc :: $flag => stringify!($flag),
+                    )+
+                    n => return write!(f, "{}", n),
+                };
+                f.write_str(string)
+            }
+        }
+    };
+}
+
 mod sockaddr;
 mod socket;
 mod utils;
+
+#[cfg(test)]
+mod tests;
 
 #[cfg(unix)]
 #[path = "sys/unix.rs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ use crate::utils::NetInt;
 /// defining the modules.
 macro_rules! impl_debug {
     (
-        // Type for which to implement `fmt::Debug`.
+        // Type name for which to implement `fmt::Debug`.
         $type: path,
         $(
             $(#[$target: meta])*

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -80,6 +80,14 @@ impl Domain {
     }
 }
 
+impl_debug!(
+    Domain,
+    libc::AF_INET,
+    libc::AF_INET6,
+    libc::AF_UNIX,
+    libc::AF_UNSPEC, // = 0.
+);
+
 /// Unix only API.
 impl Type {
     /// Set `SOCK_NONBLOCK` on the `Type`.

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -127,6 +127,14 @@ impl Type {
     }
 }
 
+impl_debug!(
+    crate::Protocol,
+    libc::IPPROTO_ICMP,
+    libc::IPPROTO_ICMPV6,
+    libc::IPPROTO_TCP,
+    libc::IPPROTO_UDP,
+);
+
 pub struct Socket {
     fd: c_int,
 }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -128,6 +128,35 @@ impl Type {
 }
 
 impl_debug!(
+    crate::Type,
+    libc::SOCK_STREAM,
+    libc::SOCK_DGRAM,
+    libc::SOCK_RAW,
+    libc::SOCK_RDM,
+    libc::SOCK_SEQPACKET,
+    /* TODO: add these optional bit OR-ed flags:
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    libc::SOCK_NONBLOCK,
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    libc::SOCK_CLOEXEC,
+    */
+);
+
+impl_debug!(
     crate::Protocol,
     libc::IPPROTO_ICMP,
     libc::IPPROTO_ICMPV6,

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -54,6 +54,14 @@ pub(crate) const IPPROTO_ICMPV6: c_int = winapi::shared::ws2def::IPPROTO_ICMPV6 
 pub(crate) const IPPROTO_TCP: c_int = winapi::shared::ws2def::IPPROTO_TCP as c_int;
 pub(crate) const IPPROTO_UDP: c_int = winapi::shared::ws2def::IPPROTO_UDP as c_int;
 
+impl_debug!(
+    crate::Domain,
+    ws2def::AF_INET,
+    ws2def::AF_INET6,
+    ws2def::AF_UNIX,
+    ws2def::AF_UNSPEC, // = 0.
+);
+
 #[repr(C)]
 struct tcp_keepalive {
     onoff: c_ulong,

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -62,6 +62,14 @@ impl_debug!(
     ws2def::AF_UNSPEC, // = 0.
 );
 
+impl_debug!(
+    crate::Protocol,
+    self::IPPROTO_ICMP,
+    self::IPPROTO_ICMPV6,
+    self::IPPROTO_TCP,
+    self::IPPROTO_UDP,
+);
+
 #[repr(C)]
 struct tcp_keepalive {
     onoff: c_ulong,

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -25,7 +25,7 @@ use winapi::shared::in6addr::*;
 use winapi::shared::inaddr::*;
 use winapi::shared::minwindef::DWORD;
 use winapi::shared::ntdef::{HANDLE, ULONG};
-use winapi::shared::ws2def::*;
+use winapi::shared::ws2def::{self, *};
 use winapi::shared::ws2ipdef::*;
 use winapi::um::handleapi::SetHandleInformation;
 use winapi::um::processthreadsapi::GetCurrentProcessId;

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -63,6 +63,15 @@ impl_debug!(
 );
 
 impl_debug!(
+    crate::Type,
+    ws2def::SOCK_STREAM,
+    ws2def::SOCK_DGRAM,
+    ws2def::SOCK_RAW,
+    ws2def::SOCK_RDM,
+    ws2def::SOCK_SEQPACKET,
+);
+
+impl_debug!(
     crate::Protocol,
     self::IPPROTO_ICMP,
     self::IPPROTO_ICMPV6,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::str;
 
-use crate::Domain;
+use crate::{Domain, Protocol};
 
 #[test]
 fn domain_fmt_debug() {
@@ -11,6 +11,25 @@ fn domain_fmt_debug() {
         #[cfg(unix)]
         (Domain::unix(), "AF_UNIX"),
         (0.into(), "AF_UNSPEC"),
+        (500.into(), "500"),
+    ];
+
+    let mut buf = Vec::new();
+    for (input, want) in tests {
+        buf.clear();
+        write!(buf, "{:?}", input).unwrap();
+        let got = str::from_utf8(&buf).unwrap();
+        assert_eq!(got, *want);
+    }
+}
+
+#[test]
+fn protocol_fmt_debug() {
+    let tests = &[
+        (Protocol::icmpv4(), "IPPROTO_ICMP"),
+        (Protocol::icmpv6(), "IPPROTO_ICMPV6"),
+        (Protocol::tcp(), "IPPROTO_TCP"),
+        (Protocol::udp(), "IPPROTO_UDP"),
         (500.into(), "500"),
     ];
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,24 @@
+use std::io::Write;
+use std::str;
+
+use crate::Domain;
+
+#[test]
+fn domain_fmt_debug() {
+    let tests = &[
+        (Domain::ipv4(), "AF_INET"),
+        (Domain::ipv6(), "AF_INET6"),
+        #[cfg(unix)]
+        (Domain::unix(), "AF_UNIX"),
+        (0.into(), "AF_UNSPEC"),
+        (500.into(), "500"),
+    ];
+
+    let mut buf = Vec::new();
+    for (input, want) in tests {
+        buf.clear();
+        write!(buf, "{:?}", input).unwrap();
+        let got = str::from_utf8(&buf).unwrap();
+        assert_eq!(got, *want);
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::str;
 
-use crate::{Domain, Protocol};
+use crate::{Domain, Protocol, Type};
 
 #[test]
 fn domain_fmt_debug() {
@@ -11,6 +11,25 @@ fn domain_fmt_debug() {
         #[cfg(unix)]
         (Domain::unix(), "AF_UNIX"),
         (0.into(), "AF_UNSPEC"),
+        (500.into(), "500"),
+    ];
+
+    let mut buf = Vec::new();
+    for (input, want) in tests {
+        buf.clear();
+        write!(buf, "{:?}", input).unwrap();
+        let got = str::from_utf8(&buf).unwrap();
+        assert_eq!(got, *want);
+    }
+}
+
+#[test]
+fn type_fmt_debug() {
+    let tests = &[
+        (Type::stream(), "SOCK_STREAM"),
+        (Type::dgram(), "SOCK_DGRAM"),
+        (Type::seqpacket(), "SOCK_SEQPACKET"),
+        (Type::raw(), "SOCK_RAW"),
         (500.into(), "500"),
     ];
 


### PR DESCRIPTION
This implementation prints the named constants rather then the raw number like the derived implementation would.

/cc @stjepang