### PR TITLE
Add Domain::for_address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@
 #![doc(html_root_url = "https://docs.rs/socket2/0.3")]
 #![deny(missing_docs)]
 
+use std::net::SocketAddr;
+
 use crate::utils::NetInt;
 
 /// Macro to implement `fmt::Debug` for a type, printing the constant names
@@ -111,6 +113,14 @@ impl Domain {
     /// Domain for IPv6 communication, corresponding to `AF_INET6`.
     pub fn ipv6() -> Domain {
         Domain(sys::AF_INET6)
+    }
+
+    /// Returns the correct domain for `address`.
+    pub fn for_address(address: SocketAddr) -> Domain {
+        match address {
+            SocketAddr::V4(_) => Domain::ipv4(),
+            SocketAddr::V6(_) => Domain::ipv6(),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub use socket::Socket;
 ///
 /// This type is freely interconvertible with C's `int` type, however, if a raw
 /// value needs to be provided.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Domain(c_int);
 
 impl Domain {
@@ -135,7 +135,7 @@ impl From<Domain> for c_int {
 ///
 /// This type is freely interconvertible with C's `int` type, however, if a raw
 /// value needs to be provided.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Type(c_int);
 
 impl Type {
@@ -184,7 +184,7 @@ impl From<Type> for c_int {
 ///
 /// This type is freely interconvertible with C's `int` type, however, if a raw
 /// value needs to be provided.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Protocol(c_int);
 
 impl Protocol {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,19 @@
 use std::io::Write;
+use std::net::SocketAddr;
 use std::str;
 
 use crate::{Domain, Protocol, Type};
+
+#[test]
+fn domain_for_address() {
+    let ipv4: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+    assert!(ipv4.is_ipv4());
+    let ipv6: SocketAddr = "[::1]:8080".parse().unwrap();
+    assert!(ipv6.is_ipv6());
+
+    assert_eq!(Domain::for_address(ipv4), Domain::ipv4());
+    assert_eq!(Domain::for_address(ipv6), Domain::ipv6());
+}
 
 #[test]
 fn domain_fmt_debug() {


### PR DESCRIPTION
Useful convenience method, not sure if you think this is too high-level @alexcrichton.

I also added `#[derive(Eq, PartialEq)]`, but this is not strictly needed but useful in tests.