### PR TITLE
Change constructor functions into constants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,24 +185,16 @@ pub struct Protocol(c_int);
 
 impl Protocol {
     /// Protocol corresponding to `ICMPv4`.
-    pub fn icmpv4() -> Self {
-        Protocol(sys::IPPROTO_ICMP)
-    }
+    pub const ICMPV4: Protocol = Protocol(sys::IPPROTO_ICMP);
 
     /// Protocol corresponding to `ICMPv6`.
-    pub fn icmpv6() -> Self {
-        Protocol(sys::IPPROTO_ICMPV6)
-    }
+    pub const ICMPV6: Protocol = Protocol(sys::IPPROTO_ICMPV6);
 
     /// Protocol corresponding to `TCP`.
-    pub fn tcp() -> Self {
-        Protocol(sys::IPPROTO_TCP)
-    }
+    pub const TCP: Protocol = Protocol(sys::IPPROTO_TCP);
 
     /// Protocol corresponding to `UDP`.
-    pub fn udp() -> Self {
-        Protocol(sys::IPPROTO_UDP)
-    }
+    pub const UDP: Protocol = Protocol(sys::IPPROTO_UDP);
 }
 
 impl From<c_int> for Protocol {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! use socket2::{Socket, Domain, Type};
 //!
 //! // create a TCP listener bound to two addresses
-//! let socket = Socket::new(Domain::IPV6, Type::stream(), None).unwrap();
+//! let socket = Socket::new(Domain::IPV6, Type::STREAM, None).unwrap();
 //!
 //! socket.bind(&"[::1]:12345".parse::<SocketAddr>().unwrap().into()).unwrap();
 //! socket.set_only_v6(false);
@@ -146,27 +146,19 @@ impl Type {
     /// Type corresponding to `SOCK_STREAM`.
     ///
     /// Used for protocols such as TCP.
-    pub fn stream() -> Type {
-        Type(sys::SOCK_STREAM)
-    }
+    pub const STREAM: Type = Type(sys::SOCK_STREAM);
 
     /// Type corresponding to `SOCK_DGRAM`.
     ///
     /// Used for protocols such as UDP.
-    pub fn dgram() -> Type {
-        Type(sys::SOCK_DGRAM)
-    }
+    pub const DGRAM: Type = Type(sys::SOCK_DGRAM);
 
     /// Type corresponding to `SOCK_SEQPACKET`.
-    pub fn seqpacket() -> Type {
-        Type(sys::SOCK_SEQPACKET)
-    }
+    pub const SEQPACKET: Type = Type(sys::SOCK_SEQPACKET);
 
     /// Type corresponding to `SOCK_RAW`.
     #[cfg(not(target_os = "redox"))]
-    pub fn raw() -> Type {
-        Type(sys::SOCK_RAW)
-    }
+    pub const RAW: Type = Type(sys::SOCK_RAW);
 }
 
 impl From<c_int> for Type {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! use socket2::{Socket, Domain, Type};
 //!
 //! // create a TCP listener bound to two addresses
-//! let socket = Socket::new(Domain::ipv6(), Type::stream(), None).unwrap();
+//! let socket = Socket::new(Domain::IPV6, Type::stream(), None).unwrap();
 //!
 //! socket.bind(&"[::1]:12345".parse::<SocketAddr>().unwrap().into()).unwrap();
 //! socket.set_only_v6(false);
@@ -104,20 +104,16 @@ pub struct Domain(c_int);
 
 impl Domain {
     /// Domain for IPv4 communication, corresponding to `AF_INET`.
-    pub fn ipv4() -> Domain {
-        Domain(sys::AF_INET)
-    }
+    pub const IPV4: Domain = Domain(sys::AF_INET);
 
     /// Domain for IPv6 communication, corresponding to `AF_INET6`.
-    pub fn ipv6() -> Domain {
-        Domain(sys::AF_INET6)
-    }
+    pub const IPV6: Domain = Domain(sys::AF_INET6);
 
     /// Returns the correct domain for `address`.
     pub fn for_address(address: SocketAddr) -> Domain {
         match address {
-            SocketAddr::V4(_) => Domain::ipv4(),
-            SocketAddr::V6(_) => Domain::ipv6(),
+            SocketAddr::V4(_) => Domain::IPV4,
+            SocketAddr::V6(_) => Domain::IPV6,
         }
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -39,7 +39,7 @@ use crate::{Domain, Protocol, SockAddr, Type};
 /// use socket2::{Socket, Domain, Type, SockAddr};
 ///
 /// // create a TCP listener bound to two addresses
-/// let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+/// let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
 ///
 /// socket.bind(&"127.0.0.1:12345".parse::<SocketAddr>().unwrap().into()).unwrap();
 /// socket.bind(&"127.0.0.1:12346".parse::<SocketAddr>().unwrap().into()).unwrap();
@@ -900,7 +900,7 @@ mod test {
         // this IP is unroutable, so connections should always time out
         let addr = "10.255.255.1:80".parse::<SocketAddr>().unwrap().into();
 
-        let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
         match socket.connect_timeout(&addr, Duration::from_millis(250)) {
             Ok(_) => panic!("unexpected success"),
             Err(ref e) if e.kind() == io::ErrorKind::TimedOut => {}
@@ -911,13 +911,13 @@ mod test {
     #[test]
     fn connect_timeout_unbound() {
         // bind and drop a socket to track down a "probably unassigned" port
-        let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
         let addr = "127.0.0.1:0".parse::<SocketAddr>().unwrap().into();
         socket.bind(&addr).unwrap();
         let addr = socket.local_addr().unwrap();
         drop(socket);
 
-        let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
         match socket.connect_timeout(&addr, Duration::from_millis(250)) {
             Ok(_) => panic!("unexpected success"),
             Err(ref e)
@@ -929,7 +929,7 @@ mod test {
 
     #[test]
     fn connect_timeout_valid() {
-        let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
         socket
             .bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into())
             .unwrap();
@@ -937,7 +937,7 @@ mod test {
 
         let addr = socket.local_addr().unwrap();
 
-        let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
         socket
             .connect_timeout(&addr, Duration::from_millis(250))
             .unwrap();
@@ -946,7 +946,7 @@ mod test {
     #[test]
     #[cfg(all(unix, feature = "pair", feature = "unix"))]
     fn pair() {
-        let (mut a, mut b) = Socket::pair(Domain::unix(), Type::stream(), None).unwrap();
+        let (mut a, mut b) = Socket::pair(Domain::UNIX, Type::stream(), None).unwrap();
         a.write_all(b"hello world").unwrap();
         let mut buf = [0; 11];
         b.read_exact(&mut buf).unwrap();
@@ -961,11 +961,11 @@ mod test {
         let dir = TempDir::new("unix").unwrap();
         let addr = SockAddr::unix(dir.path().join("sock")).unwrap();
 
-        let listener = Socket::new(Domain::unix(), Type::stream(), None).unwrap();
+        let listener = Socket::new(Domain::UNIX, Type::stream(), None).unwrap();
         listener.bind(&addr).unwrap();
         listener.listen(10).unwrap();
 
-        let mut a = Socket::new(Domain::unix(), Type::stream(), None).unwrap();
+        let mut a = Socket::new(Domain::UNIX, Type::stream(), None).unwrap();
         a.connect(&addr).unwrap();
 
         let mut b = listener.accept().unwrap().0;
@@ -978,7 +978,7 @@ mod test {
 
     #[test]
     fn keepalive() {
-        let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
         socket.set_keepalive(Some(Duration::from_secs(7))).unwrap();
         // socket.keepalive() doesn't work on Windows #24
         #[cfg(unix)]
@@ -990,7 +990,7 @@ mod test {
 
     #[test]
     fn nodelay() {
-        let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
 
         assert!(socket.set_nodelay(true).is_ok());
 
@@ -1002,7 +1002,7 @@ mod test {
 
     #[test]
     fn out_of_band_inline() {
-        let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
 
         assert_eq!(socket.out_of_band_inline().unwrap(), false);
 
@@ -1013,13 +1013,13 @@ mod test {
     #[test]
     #[cfg(any(target_os = "windows", target_os = "linux"))]
     fn out_of_band_send_recv() {
-        let s1 = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        let s1 = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
         s1.bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into())
             .unwrap();
         let s1_addr = s1.local_addr().unwrap();
         s1.listen(1).unwrap();
 
-        let s2 = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        let s2 = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
         s2.connect(&s1_addr).unwrap();
 
         let (s3, _) = s1.accept().unwrap();
@@ -1037,13 +1037,13 @@ mod test {
 
     #[test]
     fn tcp() {
-        let s1 = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        let s1 = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
         s1.bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into())
             .unwrap();
         let s1_addr = s1.local_addr().unwrap();
         s1.listen(1).unwrap();
 
-        let s2 = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        let s2 = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
         s2.connect(&s1_addr).unwrap();
 
         let (s3, _) = s1.accept().unwrap();

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -39,7 +39,7 @@ use crate::{Domain, Protocol, SockAddr, Type};
 /// use socket2::{Socket, Domain, Type, SockAddr};
 ///
 /// // create a TCP listener bound to two addresses
-/// let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+/// let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
 ///
 /// socket.bind(&"127.0.0.1:12345".parse::<SocketAddr>().unwrap().into()).unwrap();
 /// socket.bind(&"127.0.0.1:12346".parse::<SocketAddr>().unwrap().into()).unwrap();
@@ -900,7 +900,7 @@ mod test {
         // this IP is unroutable, so connections should always time out
         let addr = "10.255.255.1:80".parse::<SocketAddr>().unwrap().into();
 
-        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
         match socket.connect_timeout(&addr, Duration::from_millis(250)) {
             Ok(_) => panic!("unexpected success"),
             Err(ref e) if e.kind() == io::ErrorKind::TimedOut => {}
@@ -911,13 +911,13 @@ mod test {
     #[test]
     fn connect_timeout_unbound() {
         // bind and drop a socket to track down a "probably unassigned" port
-        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
         let addr = "127.0.0.1:0".parse::<SocketAddr>().unwrap().into();
         socket.bind(&addr).unwrap();
         let addr = socket.local_addr().unwrap();
         drop(socket);
 
-        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
         match socket.connect_timeout(&addr, Duration::from_millis(250)) {
             Ok(_) => panic!("unexpected success"),
             Err(ref e)
@@ -929,7 +929,7 @@ mod test {
 
     #[test]
     fn connect_timeout_valid() {
-        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
         socket
             .bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into())
             .unwrap();
@@ -937,7 +937,7 @@ mod test {
 
         let addr = socket.local_addr().unwrap();
 
-        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
         socket
             .connect_timeout(&addr, Duration::from_millis(250))
             .unwrap();
@@ -946,7 +946,7 @@ mod test {
     #[test]
     #[cfg(all(unix, feature = "pair", feature = "unix"))]
     fn pair() {
-        let (mut a, mut b) = Socket::pair(Domain::UNIX, Type::stream(), None).unwrap();
+        let (mut a, mut b) = Socket::pair(Domain::UNIX, Type::STREAM, None).unwrap();
         a.write_all(b"hello world").unwrap();
         let mut buf = [0; 11];
         b.read_exact(&mut buf).unwrap();
@@ -961,11 +961,11 @@ mod test {
         let dir = TempDir::new("unix").unwrap();
         let addr = SockAddr::unix(dir.path().join("sock")).unwrap();
 
-        let listener = Socket::new(Domain::UNIX, Type::stream(), None).unwrap();
+        let listener = Socket::new(Domain::UNIX, Type::STREAM, None).unwrap();
         listener.bind(&addr).unwrap();
         listener.listen(10).unwrap();
 
-        let mut a = Socket::new(Domain::UNIX, Type::stream(), None).unwrap();
+        let mut a = Socket::new(Domain::UNIX, Type::STREAM, None).unwrap();
         a.connect(&addr).unwrap();
 
         let mut b = listener.accept().unwrap().0;
@@ -978,7 +978,7 @@ mod test {
 
     #[test]
     fn keepalive() {
-        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
         socket.set_keepalive(Some(Duration::from_secs(7))).unwrap();
         // socket.keepalive() doesn't work on Windows #24
         #[cfg(unix)]
@@ -990,7 +990,7 @@ mod test {
 
     #[test]
     fn nodelay() {
-        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
 
         assert!(socket.set_nodelay(true).is_ok());
 
@@ -1002,7 +1002,7 @@ mod test {
 
     #[test]
     fn out_of_band_inline() {
-        let socket = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+        let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
 
         assert_eq!(socket.out_of_band_inline().unwrap(), false);
 
@@ -1013,13 +1013,13 @@ mod test {
     #[test]
     #[cfg(any(target_os = "windows", target_os = "linux"))]
     fn out_of_band_send_recv() {
-        let s1 = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+        let s1 = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
         s1.bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into())
             .unwrap();
         let s1_addr = s1.local_addr().unwrap();
         s1.listen(1).unwrap();
 
-        let s2 = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+        let s2 = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
         s2.connect(&s1_addr).unwrap();
 
         let (s3, _) = s1.accept().unwrap();
@@ -1037,13 +1037,13 @@ mod test {
 
     #[test]
     fn tcp() {
-        let s1 = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+        let s1 = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
         s1.bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into())
             .unwrap();
         let s1_addr = s1.local_addr().unwrap();
         s1.listen(1).unwrap();
 
-        let s2 = Socket::new(Domain::IPV4, Type::stream(), None).unwrap();
+        let s2 = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
         s2.connect(&s1_addr).unwrap();
 
         let (s3, _) = s1.accept().unwrap();

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -65,9 +65,7 @@ use crate::SockAddr;
 /// Unix only API.
 impl Domain {
     /// Domain for Unix socket communication, corresponding to `AF_UNIX`.
-    pub fn unix() -> Domain {
-        Domain(libc::AF_UNIX)
-    }
+    pub const UNIX: Domain = Domain(libc::AF_UNIX);
 
     /// Domain for low-level packet interface, corresponding to `AF_PACKET`.
     ///
@@ -75,9 +73,7 @@ impl Domain {
     ///
     /// This function is only available on Linux.
     #[cfg(target_os = "linux")]
-    pub fn packet() -> Domain {
-        Domain(libc::AF_PACKET)
-    }
+    pub const PACKET: Domain = Domain(libc::AF_PACKET);
 }
 
 impl_debug!(

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -81,6 +81,8 @@ impl_debug!(
     libc::AF_INET,
     libc::AF_INET6,
     libc::AF_UNIX,
+    #[cfg(target_os = "linux")]
+    libc::AF_PACKET,
     libc::AF_UNSPEC, // = 0.
 );
 

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -100,7 +100,7 @@ impl Type {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    pub fn non_blocking(self) -> Type {
+    pub const fn non_blocking(self) -> Type {
         Type(self.0 | libc::SOCK_NONBLOCK)
     }
 
@@ -118,7 +118,7 @@ impl Type {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    pub fn cloexec(self) -> Type {
+    pub const fn cloexec(self) -> Type {
         Type(self.0 | libc::SOCK_CLOEXEC)
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,17 +11,19 @@ fn domain_for_address() {
     let ipv6: SocketAddr = "[::1]:8080".parse().unwrap();
     assert!(ipv6.is_ipv6());
 
-    assert_eq!(Domain::for_address(ipv4), Domain::ipv4());
-    assert_eq!(Domain::for_address(ipv6), Domain::ipv6());
+    assert_eq!(Domain::for_address(ipv4), Domain::IPV4);
+    assert_eq!(Domain::for_address(ipv6), Domain::IPV6);
 }
 
 #[test]
 fn domain_fmt_debug() {
     let tests = &[
-        (Domain::ipv4(), "AF_INET"),
-        (Domain::ipv6(), "AF_INET6"),
+        (Domain::IPV4, "AF_INET"),
+        (Domain::IPV6, "AF_INET6"),
         #[cfg(unix)]
-        (Domain::unix(), "AF_UNIX"),
+        (Domain::UNIX, "AF_UNIX"),
+        #[cfg(target_os = "linux")]
+        (Domain::PACKET, "AF_UNIX"),
         (0.into(), "AF_UNSPEC"),
         (500.into(), "500"),
     ];

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -40,10 +40,11 @@ fn domain_fmt_debug() {
 #[test]
 fn type_fmt_debug() {
     let tests = &[
-        (Type::stream(), "SOCK_STREAM"),
-        (Type::dgram(), "SOCK_DGRAM"),
-        (Type::seqpacket(), "SOCK_SEQPACKET"),
-        (Type::raw(), "SOCK_RAW"),
+        (Type::STREAM, "SOCK_STREAM"),
+        (Type::DGRAM, "SOCK_DGRAM"),
+        (Type::SEQPACKET, "SOCK_SEQPACKET"),
+        #[cfg(not(target_os = "redox"))]
+        (Type::RAW, "SOCK_RAW"),
         (500.into(), "500"),
     ];
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,7 +23,7 @@ fn domain_fmt_debug() {
         #[cfg(unix)]
         (Domain::UNIX, "AF_UNIX"),
         #[cfg(target_os = "linux")]
-        (Domain::PACKET, "AF_UNIX"),
+        (Domain::PACKET, "AF_PACKET"),
         (0.into(), "AF_UNSPEC"),
         (500.into(), "500"),
     ];

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -60,10 +60,10 @@ fn type_fmt_debug() {
 #[test]
 fn protocol_fmt_debug() {
     let tests = &[
-        (Protocol::icmpv4(), "IPPROTO_ICMP"),
-        (Protocol::icmpv6(), "IPPROTO_ICMPV6"),
-        (Protocol::tcp(), "IPPROTO_TCP"),
-        (Protocol::udp(), "IPPROTO_UDP"),
+        (Protocol::ICMPV4, "IPPROTO_ICMP"),
+        (Protocol::ICMPV6, "IPPROTO_ICMPV6"),
+        (Protocol::TCP, "IPPROTO_TCP"),
+        (Protocol::UDP, "IPPROTO_UDP"),
         (500.into(), "500"),
     ];
 


### PR DESCRIPTION
Since I didn't hear anything on #64 I went ahead and implemented it. Its a breaking change that we should log somewhere (if we choose this route). Should I start a `CHANGELOG.md`?

Closes #64

/cc @stjepang