### PR TITLE
Enable some stricter warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,22 +20,30 @@
 //! # Examples
 //!
 //! ```no_run
+//! # fn main() -> std::io::Result<()> {
 //! use std::net::SocketAddr;
 //! use socket2::{Socket, Domain, Type};
 //!
 //! // create a TCP listener bound to two addresses
-//! let socket = Socket::new(Domain::IPV6, Type::STREAM, None).unwrap();
+//! let socket = Socket::new(Domain::IPV6, Type::STREAM, None)?;
 //!
-//! socket.bind(&"[::1]:12345".parse::<SocketAddr>().unwrap().into()).unwrap();
-//! socket.set_only_v6(false);
-//! socket.listen(128).unwrap();
+//! let address: SocketAddr = "[::1]:12345".parse().unwrap();
+//! socket.bind(&address.into())?;
+//! socket.set_only_v6(false)?;
+//! socket.listen(128)?;
 //!
 //! let listener = socket.into_tcp_listener();
 //! // ...
+//! # drop(listener);
+//! # Ok(()) }
 //! ```
 
 #![doc(html_root_url = "https://docs.rs/socket2/0.3")]
-#![deny(missing_docs)]
+#![deny(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+// Disallow warnings when running tests.
+#![cfg_attr(test, deny(warnings))]
+// Disallow warnings in examples.
+#![doc(test(attr(deny(warnings))))]
 
 use std::net::SocketAddr;
 

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -28,7 +28,7 @@ pub struct SockAddr {
 }
 
 impl fmt::Debug for SockAddr {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = fmt.debug_struct("SockAddr");
         builder.field("family", &self.family());
         if let Some(addr) = self.as_inet() {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -35,18 +35,23 @@ use crate::{Domain, Protocol, SockAddr, Type};
 /// # Examples
 ///
 /// ```no_run
+/// # fn main() -> std::io::Result<()> {
 /// use std::net::SocketAddr;
-/// use socket2::{Socket, Domain, Type, SockAddr};
+/// use socket2::{Socket, Domain, Type};
 ///
 /// // create a TCP listener bound to two addresses
-/// let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+/// let socket = Socket::new(Domain::IPV4, Type::STREAM, None)?;
 ///
-/// socket.bind(&"127.0.0.1:12345".parse::<SocketAddr>().unwrap().into()).unwrap();
-/// socket.bind(&"127.0.0.1:12346".parse::<SocketAddr>().unwrap().into()).unwrap();
-/// socket.listen(128).unwrap();
+/// let address: SocketAddr = "[::1]:12345".parse().unwrap();
+/// let address = address.into();
+/// socket.bind(&address)?;
+/// socket.bind(&address)?;
+/// socket.listen(128)?;
 ///
 /// let listener = socket.into_tcp_listener();
 /// // ...
+/// # drop(listener);
+/// # Ok(()) }
 /// ```
 pub struct Socket {
     // The `sys` module most have access to the socket.
@@ -794,7 +799,7 @@ impl<'a> Write for &'a Socket {
 }
 
 impl fmt::Debug for Socket {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -918,7 +918,7 @@ impl<'a> Write for &'a Socket {
 }
 
 impl fmt::Debug for Socket {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut f = f.debug_struct("Socket");
         f.field("fd", &self.fd);
         if let Ok(addr) = self.local_addr() {

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -799,7 +799,7 @@ impl<'a> Write for &'a Socket {
 }
 
 impl fmt::Debug for Socket {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut f = f.debug_struct("Socket");
         f.field("socket", &self.socket);
         if let Ok(addr) = self.local_addr() {


### PR DESCRIPTION
Also change the examples to the try operator (`?`) instead of
unwrapping.