### PR TITLE
apple: set_bound_interface

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -368,6 +368,22 @@ impl Socket {
         self.inner.set_ttl(ttl)
     }
 
+    /// Set the value of IP_BOUND_IF option on this socket.
+    ///
+    /// Name is used for finding the correct interface index.
+    #[cfg(all(feature = "all", not(target_os = "redox")))]
+    pub fn set_bound_interface(&self, name: &str) -> io::Result<()> {
+        self.inner.set_bound_interface(name)
+    }
+
+    /// Set the value of IPV6_BOUND_IF option on this socket.
+    ///
+    /// Name is used for finding the correct interface index.
+    #[cfg(all(feature = "all", not(target_os = "redox")))]
+    pub fn set_bound_interface_v6(&self, name: &str) -> io::Result<()> {
+        self.inner.set_bound_interface_v6(name)
+    }
+
     /// Gets the value of the `IPV6_UNICAST_HOPS` option for this socket.
     ///
     /// Specifies the hop limit for ipv6 unicast packets

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -370,18 +370,18 @@ impl Socket {
 
     /// Set the value of IP_BOUND_IF option on this socket.
     ///
-    /// Name is used for finding the correct interface index.
+    /// See libc::if_nametoindex on mapping interface name to interface index.
     #[cfg(all(feature = "all", not(target_os = "redox")))]
-    pub fn set_bound_interface(&self, name: &str) -> io::Result<()> {
-        self.inner.set_bound_interface(name)
+    pub fn set_bound_interface(&self, if_index: sys::c_uint) -> io::Result<()> {
+        self.inner.set_bound_interface(if_index)
     }
 
     /// Set the value of IPV6_BOUND_IF option on this socket.
     ///
-    /// Name is used for finding the correct interface index.
+    /// See libc::if_nametoindex on mapping interface name to interface index.
     #[cfg(all(feature = "all", not(target_os = "redox")))]
-    pub fn set_bound_interface_v6(&self, name: &str) -> io::Result<()> {
-        self.inner.set_bound_interface_v6(name)
+    pub fn set_bound_interface_v6(&self, if_index: sys::c_uint) -> io::Result<()> {
+        self.inner.set_bound_interface_v6(if_index)
     }
 
     /// Gets the value of the `IPV6_UNICAST_HOPS` option for this socket.

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -546,7 +546,7 @@ impl Socket {
     #[cfg(target_vendor = "apple")]
     pub fn set_bound_interface(&self, name: &str) -> io::Result<()> {
         const IP_BOUND_IF: libc::c_int = 25;
-        let name = CString::new(name).unwrap();
+        let name = CString::new(name)?;
         unsafe {
             let index = libc::if_nametoindex(name.as_ptr());
             self.setsockopt(libc::IPPROTO_IP, IP_BOUND_IF, index)
@@ -561,7 +561,7 @@ impl Socket {
     #[cfg(target_vendor = "apple")]
     pub fn set_bound_interface_v6(&self, name: &str) -> io::Result<()> {
         const IPV6_BOUND_IF: libc::c_int = 125;
-        let name = CString::new(name).unwrap();
+        let name = CString::new(name)?;
         unsafe {
             let index = libc::if_nametoindex(name.as_ptr());
             self.setsockopt(libc::IPPROTO_IPV6, IPV6_BOUND_IF, index)

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -25,7 +25,7 @@ use libc::{self, c_void, socklen_t, ssize_t};
 
 use crate::{Domain, Type};
 
-pub use libc::c_int;
+pub use libc::{c_int, c_uint};
 
 // Used in `Domain`.
 pub(crate) use libc::{AF_INET, AF_INET6};
@@ -53,7 +53,6 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         use libc::TCP_KEEPALIVE as KEEPALIVE_OPTION;
-        use std::ffi::CString;
     } else if #[cfg(any(target_os = "openbsd", target_os = "netbsd", target_os = "haiku"))] {
         use libc::SO_KEEPALIVE as KEEPALIVE_OPTION;
     } else {
@@ -544,32 +543,24 @@ impl Socket {
     }
 
     #[cfg(target_vendor = "apple")]
-    pub fn set_bound_interface(&self, name: &str) -> io::Result<()> {
+    pub fn set_bound_interface(&self, if_index: libc::c_uint) -> io::Result<()> {
         const IP_BOUND_IF: libc::c_int = 25;
-        let name = CString::new(name)?;
-        unsafe {
-            let index = libc::if_nametoindex(name.as_ptr());
-            self.setsockopt(libc::IPPROTO_IP, IP_BOUND_IF, index)
-        }
+        unsafe { self.setsockopt(libc::IPPROTO_IP, IP_BOUND_IF, if_index) }
     }
 
     #[cfg(all(feature = "all", not(target_vendor = "apple")))]
-    pub fn set_bound_interface(&self, _name: &str) -> io::Result<()> {
+    pub fn set_bound_interface(&self, _if_index: libc::c_uint) -> io::Result<()> {
         unimplemented!()
     }
 
     #[cfg(target_vendor = "apple")]
-    pub fn set_bound_interface_v6(&self, name: &str) -> io::Result<()> {
+    pub fn set_bound_interface_v6(&self, if_index: libc::c_uint) -> io::Result<()> {
         const IPV6_BOUND_IF: libc::c_int = 125;
-        let name = CString::new(name)?;
-        unsafe {
-            let index = libc::if_nametoindex(name.as_ptr());
-            self.setsockopt(libc::IPPROTO_IPV6, IPV6_BOUND_IF, index)
-        }
+        unsafe { self.setsockopt(libc::IPPROTO_IPV6, IPV6_BOUND_IF, if_index) }
     }
 
     #[cfg(all(feature = "all", not(target_vendor = "apple")))]
-    pub fn set_bound_interface_v6(&self, _name: &str) -> io::Result<()> {
+    pub fn set_bound_interface_v6(&self, _if_index: libc::c_uint) -> io::Result<()> {
         unimplemented!()
     }
 

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -432,6 +432,16 @@ impl Socket {
         unsafe { self.setsockopt(IPPROTO_IP, IP_TTL, ttl as c_int) }
     }
 
+    #[cfg(feature = "all")]
+    pub fn set_bound_interface(&self, name: &str) -> io::Result<()> {
+        unimplemented!()
+    }
+
+    #[cfg(feature = "all")]
+    pub fn set_bound_interface_v6(&self, name: &str) -> io::Result<()> {
+        unimplemented!()
+    }
+
     pub fn unicast_hops_v6(&self) -> io::Result<u32> {
         unsafe {
             let raw: c_int = self.getsockopt(IPPROTO_IPV6 as c_int, IPV6_UNICAST_HOPS)?;

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -42,7 +42,7 @@ const SD_SEND: c_int = 1;
 const SIO_KEEPALIVE_VALS: DWORD = 0x98000004;
 const WSA_FLAG_OVERLAPPED: DWORD = 0x01;
 
-pub use winapi::ctypes::c_int;
+pub use winapi::ctypes::{c_int, c_uint};
 
 // Used in `Domain`.
 pub(crate) use winapi::shared::ws2def::{AF_INET, AF_INET6};
@@ -433,12 +433,12 @@ impl Socket {
     }
 
     #[cfg(feature = "all")]
-    pub fn set_bound_interface(&self, _name: &str) -> io::Result<()> {
+    pub fn set_bound_interface(&self, _if_index: c_uint) -> io::Result<()> {
         unimplemented!()
     }
 
     #[cfg(feature = "all")]
-    pub fn set_bound_interface_v6(&self, _name: &str) -> io::Result<()> {
+    pub fn set_bound_interface_v6(&self, _if_index: c_uint) -> io::Result<()> {
         unimplemented!()
     }
 

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -433,12 +433,12 @@ impl Socket {
     }
 
     #[cfg(feature = "all")]
-    pub fn set_bound_interface(&self, name: &str) -> io::Result<()> {
+    pub fn set_bound_interface(&self, _name: &str) -> io::Result<()> {
         unimplemented!()
     }
 
     #[cfg(feature = "all")]
-    pub fn set_bound_interface_v6(&self, name: &str) -> io::Result<()> {
+    pub fn set_bound_interface_v6(&self, _name: &str) -> io::Result<()> {
         unimplemented!()
     }
 


### PR DESCRIPTION
This call works on MacOS & iOS for binding a socket to a particular interface.
It's especially useful on iOS when implementing a VPN service, where you need to decide if a new socket should be routed through the VPN or outside of it. It's not possible to do this with only the `bind(addr)`.

I'm not sure if it belongs in here or not and Linux/Windows implementation is not there yet.
What do you think?