### PR TITLE
Change crate docs to reflect new crate goals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,15 +15,23 @@
 // is platform specific, e.g. `Domain::UNIX`, is defined in `src/sys/*.rs` and
 // only for the platforms that support it.
 
-//! Utilities for handling sockets
+//! Utilities for creating and using sockets.
 //!
-//! This crate is sort of an evolution of the `net2` crate after seeing the
-//! issues on it over time. The intention of this crate is to provide as direct
-//! as possible access to the system's functionality for sockets as possible. No
-//! extra fluff (e.g. multiple syscalls or builders) provided in this crate.
-//! This also means it doesn't handle errors such as `EINTR`. As a result using
-//! this crate can be a little wordy, but it should give you maximal flexibility
-//! over configuration of sockets.
+//! The goal of this crate is to create and use a socket using advanced
+//! configuration options (those that are not available in the types in the
+//! standard library) without using any unsafe code.
+//!
+//! This crate provides as direct as possible access to the system's
+//! functionality for sockets as possible, this means **no** cross-platform
+//! utilities, no extra goodies, no creature comforts. It is up to the user to
+//! known how to use sockets when using this crate. *If you don't know how to
+//! create a socket using libc/system calls then this crate is not for you*.
+//! Most, if not all, functions directly relate to the equivalent system call
+//! with no error handling applied, so no handling errors such as [`EINTR`]. As
+//! a result using this crate can be a little wordy, but it should give you
+//! maximal flexibility over configuration of sockets.
+//!
+//! [`EINTR`]: std::io::ErrorKind::Interrupted
 //!
 //! # Examples
 //!
@@ -32,7 +40,7 @@
 //! use std::net::SocketAddr;
 //! use socket2::{Socket, Domain, Type};
 //!
-//! // create a TCP listener bound to two addresses
+//! // Create a TCP listener bound to two addresses.
 //! let socket = Socket::new(Domain::IPV6, Type::STREAM, None)?;
 //!
 //! let address: SocketAddr = "[::1]:12345".parse().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,14 @@
 //! standard library) without using any unsafe code.
 //!
 //! This crate provides as direct as possible access to the system's
-//! functionality for sockets as possible, this means **no** cross-platform
-//! utilities, no extra goodies, no creature comforts. It is up to the user to
-//! known how to use sockets when using this crate. *If you don't know how to
-//! create a socket using libc/system calls then this crate is not for you*.
-//! Most, if not all, functions directly relate to the equivalent system call
-//! with no error handling applied, so no handling errors such as [`EINTR`]. As
-//! a result using this crate can be a little wordy, but it should give you
-//! maximal flexibility over configuration of sockets.
+//! functionality for sockets, this means **no** effort to provide
+//! cross-platform utilities, no extra goodies, no creature comforts. It is up
+//! to the user to know how to use sockets when using this crate. *If you don't
+//! know how to create a socket using libc/system calls then this crate is not
+//! for you*. Most, if not all, functions directly relate to the equivalent
+//! system call with no error handling applied, so no handling errors such as
+//! [`EINTR`]. As a result using this crate can be a little wordy, but it should
+//! give you maximal flexibility over configuration of sockets.
 //!
 //! [`EINTR`]: std::io::ErrorKind::Interrupted
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// # Source code structure.
+//
+// All types and methods that are available on tier 1 all platforms are defined
+// in the first level of the source, i.e. `src/*.rs` files. Additional API that
+// is platform specific, e.g. `Domain::UNIX`, is defined in `src/sys/*.rs` and
+// only for the platforms that support it.
+
 //! Utilities for handling sockets
 //!
 //! This crate is sort of an evolution of the `net2` crate after seeing the


### PR DESCRIPTION
If everyone agrees with these new goals:

* Providing a minimal API around the libc/system calls.
* Expose as much of the API as possible, possibly behind the `all` flag for API not available on all the (tier 1) OSes.