### PR TITLE
Haiku: no SOCK_RDM support in Haiku

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -150,7 +150,7 @@ impl_debug!(
     libc::SOCK_DGRAM,
     #[cfg(not(target_os = "redox"))]
     libc::SOCK_RAW,
-    #[cfg(not(target_os = "redox"))]
+    #[cfg(not(any(target_os = "redox", target_os = "haiku")))]
     libc::SOCK_RDM,
     #[cfg(not(target_os = "redox"))]
     libc::SOCK_SEQPACKET,


### PR DESCRIPTION
Do not add SOCK_RDM when compiling for Haiku.