### PR TITLE
Correc byte ordering to convert numbers to Ipv4 addresses

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -1141,11 +1141,11 @@ fn timeval2dur(raw: libc::timeval) -> Option<Duration> {
 
 fn to_s_addr(addr: &Ipv4Addr) -> libc::in_addr_t {
     let octets = addr.octets();
-    u32::from_ne_bytes(octets).to_be()
+    u32::from_ne_bytes(octets)
 }
 
 fn from_s_addr(in_addr: libc::in_addr_t) -> Ipv4Addr {
-    in_addr.into()
+    in_addr.to_be().into()
 }
 
 fn to_in6_addr(addr: &Ipv6Addr) -> libc::in6_addr {
@@ -1191,7 +1191,7 @@ fn test_ip() {
     assert_eq!(ip, from_s_addr(to_s_addr(&ip)));
 
     let ip = Ipv4Addr::new(127, 34, 4, 12);
-    let want = 127 << 24 | 34 << 16 | 4 << 8 | 12 << 0;
+    let want = 127 << 0 | 34 << 8 | 4 << 16 | 12 << 24;
     assert_eq!(to_s_addr(&ip), want);
     assert_eq!(from_s_addr(want), ip);
 }

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -962,14 +962,14 @@ fn ms2dur(raw: DWORD) -> Option<Duration> {
 
 fn to_s_addr(addr: &Ipv4Addr) -> in_addr_S_un {
     let octets = addr.octets();
-    let res = u32::from_ne_bytes(octets).to_be();
+    let res = u32::from_ne_bytes(octets);
     let mut new_addr: in_addr_S_un = unsafe { mem::zeroed() };
     unsafe { *(new_addr.S_addr_mut()) = res };
     new_addr
 }
 
 fn from_s_addr(in_addr: in_addr_S_un) -> Ipv4Addr {
-    unsafe { *in_addr.S_addr() }.into()
+    unsafe { *in_addr.S_addr() }.to_be().into()
 }
 
 fn to_in6_addr(addr: &Ipv6Addr) -> in6_addr {
@@ -1007,7 +1007,7 @@ fn test_ip() {
     assert_eq!(ip, from_s_addr(to_s_addr(&ip)));
 
     let ip = Ipv4Addr::new(127, 34, 4, 12);
-    let want = 127 << 24 | 34 << 16 | 4 << 8 | 12 << 0;
+    let want = 127 << 0 | 34 << 8 | 4 << 16 | 12 << 24;
     assert_eq!(unsafe { *to_s_addr(&ip).S_addr() }, want);
     let mut addr: in_addr_S_un = unsafe { mem::zeroed() };
     unsafe { *(addr.S_addr_mut()) = want };


### PR DESCRIPTION
This commit changes the byte order when converting IPv4 Addresses, as
the order was reversed.

The test program used to validate it works was sending a multicast
address to `join_multicast_v4` which was not accepted by either Windows
or Linux. Now the test program compiles and run without issues.

```rust
use socket2::{Domain, Protocol, Socket, Type};
use std::net::Ipv4Addr;

fn main() {
    let socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))
        .expect("could not create socket");
    socket
        .join_multicast_v4(&Ipv4Addr::new(224, 0, 0, 251), &Ipv4Addr::UNSPECIFIED)
        .expect("could not join multicast group");
}
```

Fixes https://github.com/alexcrichton/socket2-rs/issues/87