### PR TITLE
Revert "add back Domain::ipv{4,6} (#96)"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,16 +137,6 @@ impl Domain {
     /// Domain for IPv6 communication, corresponding to `AF_INET6`.
     pub const IPV6: Domain = Domain(sys::AF_INET6);
 
-    /// Domain for IPv4 communication, corresponding to `AF_INET`.
-    pub fn ipv4() -> Domain {
-        Domain::IPV4
-    }
-
-    /// Domain for IPv6 communication, corresponding to `AF_INET6`.
-    pub fn ipv6() -> Domain {
-        Domain::IPV6
-    }
-
     /// Returns the correct domain for `address`.
     pub fn for_address(address: SocketAddr) -> Domain {
         match address {


### PR DESCRIPTION
This was added because it was a breaking change in the v0.3.x API, but
for the v0.4.x API this is no longer needed as the associated constants
would be the preferred way to create Domain.

This reverts commit 7e20f55e949054e108c5b8f114bcc8b2a0051ce7.