### PR TITLE
Use IPPROTO_IPV6 in join_multicast_v6.

### DIFF
--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -588,7 +588,7 @@ impl Socket {
             ipv6mr_multiaddr: multiaddr,
             ipv6mr_interface: interface,
         };
-        unsafe { self.setsockopt(IPPROTO_IP, IPV6_ADD_MEMBERSHIP, mreq) }
+        unsafe { self.setsockopt(IPPROTO_IPV6 as c_int, IPV6_ADD_MEMBERSHIP, mreq) }
     }
 
     pub fn leave_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {


### PR DESCRIPTION
IPPROTO_IPV6 is used for IPV6_ADD_MEMBERSHIP. [Source](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ipv6-socket-options), if that's even necessary.

Minimal reproducible example:
```rust
use socket2::{Domain, Socket, Type};
use std::net::Ipv6Addr;
const IPV6_ADDR: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x00fb);

fn main() -> std::io::Result<()> {
    let socket = Socket::new(Domain::IPV6, Type::DGRAM, None)?;
    socket.join_multicast_v6(&IPV6_ADDR, 0)?; // returns an Err on Windows
    Ok(())
}
```