### PR TITLE
Use accept4 on *BSD as well as Linux.

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -428,7 +428,15 @@ impl Socket {
         let mut len = mem::size_of_val(&storage) as socklen_t;
 
         let mut socket = None;
-        #[cfg(target_os = "linux")]
+        #[cfg(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "illumos",
+            target_os = "linux",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
         {
             let res = syscall!(accept4(
                 self.fd,
@@ -437,7 +445,7 @@ impl Socket {
                 libc::SOCK_CLOEXEC,
             ));
             match res {
-                Ok(fd) => socket = Some(Socket { fd: fd }),
+                Ok(fd) => socket = Some(Socket { fd }),
                 Err(ref e) if e.raw_os_error() == Some(libc::ENOSYS) => {}
                 Err(e) => return Err(e),
             }


### PR DESCRIPTION
The modern BSDs have `accept4` too, so we should use it if it is available. The existing code already contains a fallback in case the syscall doesn't exist.

DragonflyBSD has it since 4.3: https://man.dragonflybsd.org/?command=accept4&section=2 (see the HISTORY section)
FreeBSD has it since 10.0: https://www.freebsd.org/cgi/man.cgi?query=accept&&manpath=FreeBSD+10.0-RELEASE
NetBSD has it since 8.0: https://man.netbsd.org/NetBSD-8.0/accept.2
OpenBSD has it since 5.7: https://man.openbsd.org/OpenBSD-5.7/accept.2

NetBSD also has an equivalent `paccept` since 5.0, but I didn't think it worth it to add another code path for that.