### PR TITLE
Refactor part 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socket2"
-version = "0.3.14"
+version = "0.4.0-dev"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -21,7 +21,7 @@ use winapi::um::winsock2::MSG_OOB;
 use crate::sys;
 use crate::{Domain, Protocol, SockAddr, Type};
 
-/// Newtype, owned, wrapper around a system socket.
+/// Owned wrapper around a system socket.
 ///
 /// This type simply wraps an instance of a file descriptor (`c_int`) on Unix
 /// and an instance of `SOCKET` on Windows. This is the main type exported by
@@ -29,6 +29,13 @@ use crate::{Domain, Protocol, SockAddr, Type};
 /// platforms as closely as possible. Almost all methods correspond to
 /// precisely one libc or OS API call which is essentially just a "Rustic
 /// translation" of what's below.
+///
+/// This type can be freely converted into the network primitives provided by
+/// the standard library, such as [`TcpStream`] or [`UdpSocket`], using the
+/// [`Into`] trait, see the example below.
+///
+/// [`TcpStream`]: std::net::TcpStream
+/// [`UdpSocket`]: std::net::UdpSocket
 ///
 /// # Examples
 ///


### PR DESCRIPTION
In this rewrite the sys module will only expose the type used by the OS
to represent a socket (e.g. SOCKET on Windows or a file descriptor on
Unix) and the required functions.

This should reduce the number of lines of code for this crate. Something
similar was done in the Mio crate which reduced the SLOC by roughly 2k.