### PR TITLE
Refactor part 2: change Socket::new to only call socket(2)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! ```no_run
 //! # fn main() -> std::io::Result<()> {
-//! use std::net::SocketAddr;
+//! use std::net::{SocketAddr, TcpListener};
 //! use socket2::{Socket, Domain, Type};
 //!
 //! // Create a TCP listener bound to two addresses.
@@ -46,7 +46,7 @@
 //! socket.set_only_v6(false)?;
 //! socket.listen(128)?;
 //!
-//! let listener = socket.into_tcp_listener();
+//! let listener: TcpListener = socket.into();
 //! // ...
 //! # drop(listener);
 //! # Ok(()) }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -41,7 +41,7 @@ use crate::{Domain, Protocol, SockAddr, Type};
 ///
 /// ```no_run
 /// # fn main() -> std::io::Result<()> {
-/// use std::net::SocketAddr;
+/// use std::net::{SocketAddr, TcpListener};
 /// use socket2::{Socket, Domain, Type};
 ///
 /// // create a TCP listener bound to two addresses
@@ -53,7 +53,7 @@ use crate::{Domain, Protocol, SockAddr, Type};
 /// socket.bind(&address)?;
 /// socket.listen(128)?;
 ///
-/// let listener = socket.into_tcp_listener();
+/// let listener: TcpListener = socket.into();
 /// // ...
 /// # drop(listener);
 /// # Ok(()) }
@@ -97,45 +97,6 @@ impl Socket {
                 inner: sockets.1.inner(),
             },
         ))
-    }
-
-    /// Consumes this `Socket`, converting it to a `TcpStream`.
-    pub fn into_tcp_stream(self) -> net::TcpStream {
-        self.into()
-    }
-
-    /// Consumes this `Socket`, converting it to a `TcpListener`.
-    pub fn into_tcp_listener(self) -> net::TcpListener {
-        self.into()
-    }
-
-    /// Consumes this `Socket`, converting it to a `UdpSocket`.
-    pub fn into_udp_socket(self) -> net::UdpSocket {
-        self.into()
-    }
-
-    /// Consumes this `Socket`, converting it into a `UnixStream`.
-    ///
-    /// This function is only available on Unix.
-    #[cfg(all(feature = "all", unix))]
-    pub fn into_unix_stream(self) -> UnixStream {
-        self.into()
-    }
-
-    /// Consumes this `Socket`, converting it into a `UnixListener`.
-    ///
-    /// This function is only available on Unix.
-    #[cfg(all(feature = "all", unix))]
-    pub fn into_unix_listener(self) -> UnixListener {
-        self.into()
-    }
-
-    /// Consumes this `Socket`, converting it into a `UnixDatagram`.
-    ///
-    /// This function is only available on Unix.
-    #[cfg(all(feature = "all", unix))]
-    pub fn into_unix_datagram(self) -> UnixDatagram {
-        self.into()
     }
 
     /// Initiate a connection on this socket to the specified address.

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -129,6 +129,18 @@ pub(crate) fn socket(family: c_int, ty: c_int, protocol: c_int) -> io::Result<Sy
     }
 }
 
+impl crate::Socket {
+    /// Sets `HANDLE_FLAG_INHERIT` to zero using `SetHandleInformation`.
+    pub fn set_no_inherit(&self) -> io::Result<()> {
+        let r = unsafe { SetHandleInformation(self.inner as HANDLE, HANDLE_FLAG_INHERIT, 0) };
+        if r == 0 {
+            Err(last_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
 #[repr(transparent)] // Required during rewriting.
 pub struct Socket {
     socket: SysSocket,


### PR DESCRIPTION
If socket2 is going to be a fully configuration socket(2) wrapper, then
the user needs to determine if things like setting CLOEXEC is desirable.
The new example shows the common case of setting all those flags.

We should consider adding a `Socket::new_with_common_flags()`, which would create a socket with all advisable flags set such as in the new example.