### PR TITLE
Return new `RecvFlags` struct with vectored I/O.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,29 +247,6 @@ pub struct RecvFlags(c_int);
 
 #[cfg(not(target_os = "redox"))]
 impl RecvFlags {
-    /// Check if the message terminates a record.
-    ///
-    /// Not all socket types support the notion of records.
-    /// For socket types that do support it (such as [`SEQPACKET`][Type::SEQPACKET]),
-    /// a record is terminated by sending a message with the end-of-record flag set.
-    ///
-    /// On Unix this corresponds to the MSG_EOR flag.
-    #[cfg(unix)]
-    pub fn is_end_of_record(self) -> bool {
-        self.0 & sys::MSG_EOR != 0
-    }
-
-    /// Check if the message contains out-of-band data.
-    ///
-    /// This is useful for protocols where you receive out-of-band data
-    /// mixed in with the normal data stream.
-    ///
-    /// On Unix this corresponds to the MSG_OOB flag.
-    #[cfg(unix)]
-    pub fn is_out_of_band(self) -> bool {
-        self.0 & sys::MSG_OOB != 0
-    }
-
     /// Check if the message contains a truncated datagram.
     ///
     /// This flag is only used for datagram-based sockets,
@@ -279,18 +256,5 @@ impl RecvFlags {
     /// On Windows this corresponds to the WSAEMSGSIZE error code.
     pub fn is_truncated(self) -> bool {
         self.0 & sys::MSG_TRUNC != 0
-    }
-}
-
-#[cfg(not(target_os = "redox"))]
-impl std::fmt::Debug for RecvFlags {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut dbg = f.debug_struct("RecvFlags");
-        #[cfg(unix)]
-        dbg.field("is_end_of_record", &self.is_end_of_record());
-        #[cfg(unix)]
-        dbg.field("is_out_of_band", &self.is_out_of_band());
-        dbg.field("is_truncated", &self.is_truncated());
-        dbg.finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ impl RecvFlags {
     ///
     /// On Unix this corresponds to the MSG_TRUNC flag.
     /// On Windows this corresponds to the WSAEMSGSIZE error code.
-    pub fn is_trunctated(self) -> bool {
+    pub fn is_truncated(self) -> bool {
         self.0 & sys::MSG_TRUNC != 0
     }
 }
@@ -290,7 +290,7 @@ impl std::fmt::Debug for RecvFlags {
         dbg.field("is_end_of_record", &self.is_end_of_record());
         #[cfg(unix)]
         dbg.field("is_out_of_band", &self.is_out_of_band());
-        dbg.field("is_truncated", &self.is_trunctated());
+        dbg.field("is_truncated", &self.is_truncated());
         dbg.finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ impl std::fmt::Debug for RecvFlags {
         dbg.field("is_end_of_record", &self.is_end_of_record());
         #[cfg(unix)]
         dbg.field("is_out_of_band", &self.is_out_of_band());
-        dbg.field("is_trunctated", &self.is_trunctated());
+        dbg.field("is_truncated", &self.is_trunctated());
         dbg.finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,3 +237,60 @@ impl From<Protocol> for c_int {
         p.0
     }
 }
+
+/// Flags for incoming messages.
+///
+/// Flags provide additional information about incoming messages.
+#[cfg(not(target_os = "redox"))]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct RecvFlags(c_int);
+
+#[cfg(not(target_os = "redox"))]
+impl RecvFlags {
+    /// Check if the message terminates a record.
+    ///
+    /// Not all socket types support the notion of records.
+    /// For socket types that do support it (such as [`SEQPACKET`][Type::SEQPACKET]),
+    /// a record is terminated by sending a message with the end-of-record flag set.
+    ///
+    /// On Unix this corresponds to the MSG_EOR flag.
+    #[cfg(unix)]
+    pub fn is_end_of_record(self) -> bool {
+        self.0 & sys::MSG_EOR != 0
+    }
+
+    /// Check if the message contains out-of-band data.
+    ///
+    /// This is useful for protocols where you receive out-of-band data
+    /// mixed in with the normal data stream.
+    ///
+    /// On Unix this corresponds to the MSG_OOB flag.
+    #[cfg(unix)]
+    pub fn is_out_of_band(self) -> bool {
+        self.0 & sys::MSG_OOB != 0
+    }
+
+    /// Check if the message contains a truncated datagram.
+    ///
+    /// This flag is only used for datagram-based sockets,
+    /// not for stream sockets.
+    ///
+    /// On Unix this corresponds to the MSG_TRUNC flag.
+    /// On Windows this corresponds to the WSAEMSGSIZE error code.
+    pub fn is_trunctated(self) -> bool {
+        self.0 & sys::MSG_TRUNC != 0
+    }
+}
+
+#[cfg(not(target_os = "redox"))]
+impl std::fmt::Debug for RecvFlags {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut dbg = f.debug_struct("RecvFlags");
+        #[cfg(unix)]
+        dbg.field("is_end_of_record", &self.is_end_of_record());
+        #[cfg(unix)]
+        dbg.field("is_out_of_band", &self.is_out_of_band());
+        dbg.field("is_trunctated", &self.is_trunctated());
+        dbg.finish()
+    }
+}

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -21,6 +21,8 @@ use libc::MSG_OOB;
 use winapi::um::winsock2::MSG_OOB;
 
 use crate::sys;
+#[cfg(not(target_os = "redox"))]
+use crate::RecvFlags;
 use crate::{Domain, Protocol, SockAddr, Type};
 
 /// Owned wrapper around a system socket.
@@ -264,8 +266,8 @@ impl Socket {
 
     /// Identical to [`recv_with_flags`] but reads into a slice of buffers.
     ///
-    /// In addition to the number of bytes read, this function a flag to indicate if a received datagram was truncated.
-    /// For stream sockets, the flag has no meaning.
+    /// In addition to the number of bytes read, this function return the flags for the received message.
+    /// See [`RecvFlags`] for more information about the flags.
     ///
     /// [`recv_with_flags`]: #method.recv_with_flags
     #[cfg(not(target_os = "redox"))]
@@ -273,7 +275,7 @@ impl Socket {
         &self,
         bufs: &mut [IoSliceMut<'_>],
         flags: i32,
-    ) -> io::Result<(usize, bool)> {
+    ) -> io::Result<(usize, RecvFlags)> {
         self.inner().recv_vectored(bufs, flags)
     }
 
@@ -319,8 +321,8 @@ impl Socket {
 
     /// Identical to [`recv_from_with_flags`] but reads into a slice of buffers.
     ///
-    /// In addition to the number of bytes read, this function a flag to indicate if a received datagram was truncated.
-    /// For stream sockets, the flag has no meaning.
+    /// In addition to the number of bytes read, this function return the flags for the received message.
+    /// See [`RecvFlags`] for more information about the flags.
     ///
     /// [`recv_from_with_flags`]: #method.recv_from_with_flags
     #[cfg(not(target_os = "redox"))]
@@ -328,7 +330,7 @@ impl Socket {
         &self,
         bufs: &mut [IoSliceMut<'_>],
         flags: i32,
-    ) -> io::Result<(usize, bool, SockAddr)> {
+    ) -> io::Result<(usize, RecvFlags, SockAddr)> {
         self.inner().recv_from_vectored(bufs, flags)
     }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -266,7 +266,7 @@ impl Socket {
 
     /// Identical to [`recv_with_flags`] but reads into a slice of buffers.
     ///
-    /// In addition to the number of bytes read, this function return the flags for the received message.
+    /// In addition to the number of bytes read, this function returns the flags for the received message.
     /// See [`RecvFlags`] for more information about the flags.
     ///
     /// [`recv_with_flags`]: #method.recv_with_flags
@@ -321,7 +321,7 @@ impl Socket {
 
     /// Identical to [`recv_from_with_flags`] but reads into a slice of buffers.
     ///
-    /// In addition to the number of bytes read, this function return the flags for the received message.
+    /// In addition to the number of bytes read, this function returns the flags for the received message.
     /// See [`RecvFlags`] for more information about the flags.
     ///
     /// [`recv_from_with_flags`]: #method.recv_from_with_flags

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -212,6 +212,7 @@ impl_debug!(
 );
 
 /// Unix-only API.
+#[cfg(not(target_os = "redox"))]
 impl RecvFlags {
     /// Check if the message terminates a record.
     ///

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -44,8 +44,9 @@ pub use winapi::ctypes::c_int;
 
 /// Fake MSG_TRUNC flag for the [`RecvFlags`] struct.
 ///
-/// Value copied from Linux.
-pub(crate) const MSG_TRUNC: c_int = 0x20;
+/// The flag is enabled when a `WSARecv[From]` call returns `WSAEMSGSIZE`.
+/// The value of the flag is defined by us.
+pub(crate) const MSG_TRUNC: c_int = 0x01;
 
 // Used in `Domain`.
 pub(crate) use winapi::shared::ws2def::{AF_INET, AF_INET6};
@@ -102,6 +103,14 @@ impl_debug!(
     self::IPPROTO_TCP,
     self::IPPROTO_UDP,
 );
+
+impl std::fmt::Debug for RecvFlags {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RecvFlags")
+            .field("is_truncated", &self.is_truncated())
+            .finish()
+    }
+}
 
 #[repr(C)]
 struct tcp_keepalive {

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -43,7 +43,9 @@ const WSA_FLAG_OVERLAPPED: DWORD = 0x01;
 pub use winapi::ctypes::c_int;
 
 /// Fake MSG_TRUNC flag for the [`RecvFlags`] struct.
-pub(crate) const MSG_TRUNC: c_int = sock::WSAEMSGSIZE;
+///
+/// Value copied from Linux.
+pub(crate) const MSG_TRUNC: c_int = 0x20;
 
 // Used in `Domain`.
 pub(crate) use winapi::shared::ws2def::{AF_INET, AF_INET6};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -194,7 +194,7 @@ fn send_recv_vectored() {
     assert_eq!(flags.is_end_of_record(), false);
     #[cfg(all(unix, not(target_os = "redox")))]
     assert_eq!(flags.is_out_of_band(), false);
-    assert_eq!(flags.is_trunctated(), false);
+    assert_eq!(flags.is_truncated(), false);
 
     assert_eq!(&the, b"the");
     assert_eq!(&wee, b"wee");
@@ -247,7 +247,7 @@ fn send_from_recv_to_vectored() {
     assert_eq!(flags.is_end_of_record(), false);
     #[cfg(all(unix, not(target_os = "redox")))]
     assert_eq!(flags.is_out_of_band(), false);
-    assert_eq!(flags.is_trunctated(), false);
+    assert_eq!(flags.is_truncated(), false);
     assert_eq!(addr.as_inet6().unwrap(), addr_a.as_inet6().unwrap());
     assert_eq!(&surgeon, b"surgeon");
     assert_eq!(&has, b"has");
@@ -273,7 +273,7 @@ fn recv_vectored_truncated() {
         .recv_vectored(&mut [IoSliceMut::new(&mut buffer)], 0)
         .unwrap();
     assert_eq!(received, 24);
-    assert_eq!(flags.is_trunctated(), true);
+    assert_eq!(flags.is_truncated(), true);
     assert_eq!(&buffer, b"do not feed the gremlins");
 }
 
@@ -297,7 +297,7 @@ fn recv_from_vectored_truncated() {
         .recv_from_vectored(&mut [IoSliceMut::new(&mut buffer)], 0)
         .unwrap();
     assert_eq!(received, 24);
-    assert_eq!(flags.is_trunctated(), true);
+    assert_eq!(flags.is_truncated(), true);
     assert_eq!(addr.as_inet6().unwrap(), addr_a.as_inet6().unwrap());
     assert_eq!(&buffer, b"do not feed the gremlins");
 }


### PR DESCRIPTION
The `RecvFlags` struct replaces the boolean to indicate if messages are truncated. This is intended to address #113.

Currently it only supports POSIX flags on Unix, no Linux specific flags, although that would be trivial to add.

On Windows, it only supports `is_truncated()`, because the other flags don't exist.