### PR TITLE
Haiku: no SOCK_RDM support in Haiku

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -132,6 +132,7 @@ impl_debug!(
     libc::SOCK_STREAM,
     libc::SOCK_DGRAM,
     libc::SOCK_RAW,
+    #[cfg(not(target_os = "haiku"))]
     libc::SOCK_RDM,
     libc::SOCK_SEQPACKET,
     /* TODO: add these optional bit OR-ed flags:


### PR DESCRIPTION
This is a backport of a Haiku fix for the v0.3.x branch, as requested in #97.